### PR TITLE
Feature/arg_parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *_test
 *_main
+*.tree
 .idea/
 .vscode/
 obj/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,10 @@ add_executable(galaxy src/main.c)
 target_include_directories(galaxy PRIVATE include)
 
 # Link the lexer library to galaxy
-target_link_libraries(galaxy PRIVATE lexer parser)
+target_link_libraries(galaxy PRIVATE lexer parser arg_parse)
 
 # Add subdirectories for lexer, parser, and node_definitions
 add_subdirectory(src/frontend/lexer)
 add_subdirectory(src/frontend/parser)
 add_subdirectory(src/frontend/node_definitions)
+add_subdirectory(src/args)

--- a/include/args/definitions.h
+++ b/include/args/definitions.h
@@ -1,0 +1,27 @@
+#ifndef ARG_PARSE_DEF
+#define ARG_PARSE_DEF
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum {
+  TARGET
+} ArgTypes;
+
+typedef struct {
+  char* flag;
+  char *value;
+} Argument;
+
+typedef struct {
+    Argument *named_args;
+    int named_count;
+    char **positional_args;
+    int positional_count;
+} ArgParseResult;
+
+ArgParseResult arg_parse(int argc, char *argv[]);
+void free_arg_parse(ArgParseResult *result);
+
+#endif

--- a/src/args/CMakeLists.txt
+++ b/src/args/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+# Define the main executable from the ../main.c file
+add_library(arg_parse arg_parse.c)
+target_include_directories(arg_parser PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+# Add subdirectories for args_parser
+add_subdirectory(./parser)

--- a/src/args/CMakeLists.txt
+++ b/src/args/CMakeLists.txt
@@ -1,7 +1,2 @@
-
-# Define the main executable from the ../main.c file
-add_library(arg_parse arg_parse.c)
-target_include_directories(arg_parser PUBLIC ${CMAKE_SOURCE_DIR}/include)
-
-# Add subdirectories for args_parser
-add_subdirectory(./parser)
+add_library(arg_parse parser/arg_parser.c)
+target_include_directories(arg_parse PUBLIC ${CMAKE_SOURCE_DIR}/include/args)

--- a/src/args/parser/CMakeLists.txt
+++ b/src/args/parser/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(args_parser.c)
+
+target_include_directories(args_parser.c PUBLIC ../../include)
+
+target_link_libraries(args_parser.c PRIVATE args)
+
+target_sources(args_parser.c PRIVATE args_parser.c)

--- a/src/args/parser/arg_parse.c
+++ b/src/args/parser/arg_parse.c
@@ -1,0 +1,31 @@
+#include "../../../include/args/definitions.h";
+
+void free_arg_parse(ArgParseResult *result) {
+  free(result->named_args);
+  free(result->positional_args);
+  free(result);
+}
+
+ArgParseResult arg_parse(int argc, char *argv[]) {
+  ArgParseResult result;
+
+  result.named_args = calloc(argc, sizeof(Argument));
+  result.named_count = 0;
+  result.positional_args = calloc(argc, sizeof(char *));
+  result.positional_count = 0;
+
+  for (int i = 0; i < argc; i++ && argv[i + 1][0] != '-')
+  {
+    if (argv[i][0] == '-') {
+      result.named_args[result.named_count].flag = argv[i];
+      result.named_args[result.named_count].value = argv[i + 1];
+      result.named_count++;
+      i++;
+    } else {
+      result.positional_args[result.positional_count] = argv[i];
+      result.positional_count++;
+    }
+  }
+
+  return result;
+}

--- a/src/args/parser/arg_parser.c
+++ b/src/args/parser/arg_parser.c
@@ -1,11 +1,25 @@
 #include "../../../include/args/definitions.h";
 
+/**
+ * @brief Frees the memory allocated for named and positional arguments in ArgParseResult.
+ *
+ * This function releases the dynamically allocated memory for the named arguments
+ * and positional arguments contained within the ArgParseResult structure.
+ *
+ * @param result Pointer to the ArgParseResult structure whose memory is to be freed.
+ */
 void free_arg_parse(ArgParseResult *result) {
   free(result->named_args);
   free(result->positional_args);
-  free(result);
 }
 
+/**
+ * @brief Parse the command line arguments into named and positional arguments.
+ *
+ * @param argc The number of command line arguments.
+ * @param argv The array of command line arguments.
+ * @return The parsed command line arguments.
+ */
 ArgParseResult arg_parse(int argc, char *argv[]) {
   ArgParseResult result;
 
@@ -14,14 +28,14 @@ ArgParseResult arg_parse(int argc, char *argv[]) {
   result.positional_args = calloc(argc, sizeof(char *));
   result.positional_count = 0;
 
-  for (int i = 0; i < argc; i++ && argv[i + 1][0] != '-')
-  {
-    if (argv[i][0] == '-') {
+  for (int i = 0; i < argc; i++) {
+    if (i + 1 < argc && argv[i][0] == '-') {
       result.named_args[result.named_count].flag = argv[i];
       result.named_args[result.named_count].value = argv[i + 1];
       result.named_count++;
       i++;
-    } else {
+    }
+    else {
       result.positional_args[result.positional_count] = argv[i];
       result.positional_count++;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include "../include/lexer/core.h"
 #include "../include/parser/core.h"
 #include "../include/utils.h"
+#include "../include/args/definitions.h"
 
 /**
  * @brief Frees the memory allocated for an array of tokens.
@@ -16,24 +17,39 @@
 void freeTokens(Token *tokens, int tokenCount) {
     if (tokens != NULL) {
         for (int i = 0; i < tokenCount; i++) {
-            FREE_S(tokens[i].lexeme);  
-            FREE_S(tokens[i].message); 
+            FREE_S(tokens[i].lexeme);
+            FREE_S(tokens[i].message);
         }
-        FREE_S(tokens);  
+        FREE_S(tokens);
     }
 }
 
 /**
  * @brief Entry point for the program.
  *
- * Processes a source file by tokenizing its contents, generating an abstract syntax tree (AST), 
- * and cleaning up allocated resources. 
+ * Processes a source file by tokenizing its contents, generating an abstract syntax tree (AST),
+ * and cleaning up allocated resources.
  *
  * @param argc Number of command-line arguments.
  * @param argv Command-line arguments: program name and source file path.
  * @return 0 on success, or a non-zero error code on failure.
  */
 int main(int argc, char **argv) {
+  ArgParseResult args = arg_parse(argc, argv);
+
+    printf("Named arguments:\n");
+    for (int i = 0; i < args.named_count; i++) {
+        printf("  %s: %s\n", args.named_args[i].flag, args.named_args[i].value);
+    }
+
+    printf("Positional arguments:\n");
+    for (int i = 0; i < args.positional_count; i++) {
+        printf("  %s\n", args.positional_args[i]);
+    }
+
+    free_arg_parse(&args);
+
+
     if (argc < 2) {
         printf("Usage: %s <source_file>\n", argv[0]);
         return 1;
@@ -47,7 +63,7 @@ int main(int argc, char **argv) {
 
     int count = 0;
     Token *tokens = tokenize(sourceFile, argv[1], &count);
-    
+
     Parser parser = parser_new();
     AstNode *ast = produce_ast(&parser, tokens, count);
 

--- a/src/main.c
+++ b/src/main.c
@@ -37,38 +37,31 @@ void freeTokens(Token *tokens, int tokenCount) {
 int main(int argc, char **argv) {
   ArgParseResult args = arg_parse(argc, argv);
 
-    printf("Named arguments:\n");
-    for (int i = 0; i < args.named_count; i++) {
-        printf("  %s: %s\n", args.named_args[i].flag, args.named_args[i].value);
-    }
+  //TODO: implement arg_parse function for flags
 
-    printf("Positional arguments:\n");
-    for (int i = 0; i < args.positional_count; i++) {
-        printf("  %s\n", args.positional_args[i]);
-    }
+  free_arg_parse(&args);
 
-    free_arg_parse(&args);
+  if (argc < 2) {
+      printf("Usage: %s <source_file>\n", argv[0]);
+      return 1;
+  }
 
+  char * arg_source_file = argv[1];
 
-    if (argc < 2) {
-        printf("Usage: %s <source_file>\n", argv[0]);
-        return 1;
-    }
+  FILE *sourceFile;
+  if (!fopen_safe(sourceFile, argv[1], "r")) {
+      fprintf(stderr, "Error opening file '%s'\n", arg_source_file);
+      return 1;
+  }
 
-    FILE *sourceFile;
-    if (!fopen_safe(sourceFile, argv[1], "r")) {
-        fprintf(stderr, "Error opening file '%s'\n", argv[1]);
-        return 1;
-    }
+  int count = 0;
+  Token *tokens = tokenize(sourceFile, arg_source_file, &count);
 
-    int count = 0;
-    Token *tokens = tokenize(sourceFile, argv[1], &count);
+  Parser parser = parser_new();
+  AstNode *ast = produce_ast(&parser, tokens, count);
 
-    Parser parser = parser_new();
-    AstNode *ast = produce_ast(&parser, tokens, count);
-
-    free_ast_node(ast);
-    freeTokens(tokens, count);
-    fclose(sourceFile);
-    return 0;
+  free_ast_node(ast);
+  freeTokens(tokens, count);
+  fclose(sourceFile);
+  return 0;
 }


### PR DESCRIPTION
# Add:
- parse the command line arguments into named and positional arguments.
  - ```ArgParseResult arg_parse(int argc, char *argv[])```
- Frees the memory allocated for named and positional arguments in ArgParseResult.
  - ```free_arg_parse(ArgParseResult *result)```

# Types

```c

typedef struct {
    Argument *named_args;
    int named_count;
    char **positional_args;
    int positional_count;
} ArgParseResult;

typedef struct {
  char* flag;
  char *value;
} Argument;

````